### PR TITLE
fix: correct XDG_CONFIG_HOME path expansion in neovim install script

### DIFF
--- a/neovim/install.sh
+++ b/neovim/install.sh
@@ -27,6 +27,6 @@ brew install neovim
 # Install dependencies.
 brew install ripgrep
 
-git clone https://github.com/dam9000/kickstart-modular.nvim.git "$XDG_CONFIG_HOME:-$HOME/.config/nvim"
+git clone https://github.com/dam9000/kickstart-modular.nvim.git "${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
 
 success 'Neovim installed'


### PR DESCRIPTION
Closes #82